### PR TITLE
chore: switch CI credentials to renamed GitHub Apps

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -14,7 +14,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ vars.DEPENDABOT_AUTO_MERGE_BOT_APP_ID }}
+          client-id: ${{ vars.DEPENDABOT_AUTO_MERGE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.DEPENDABOT_AUTO_MERGE_BOT_PRIVATE_KEY }}
 
       - name: Dependabot metadata

--- a/.github/workflows/backup-repository-settings.yml
+++ b/.github/workflows/backup-repository-settings.yml
@@ -4,9 +4,8 @@ name: Backup Repository Settings
 on:
   # Triggers the workflow on push events (excluding develop branches) and manual runs
   push:
-    branches-ignore:
-      - 'develop'
-      - 'develop*'
+    branches:
+      - main
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ vars.SEMANTIC_RELEASE_GIT_PERMISSION_BOT_APP_ID }}
-          private-key: ${{ secrets.SEMANTIC_RELEASE_GIT_PERMISSION_BOT_PRIVATE_KEY }}
+          client-id: ${{ vars.SEMANTIC_RELEASE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.SEMANTIC_RELEASE_BOT_PRIVATE_KEY }}
 
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -45,4 +45,3 @@ jobs:
         run: pnpm exec semantic-release
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }} # Used for npm publish

--- a/README.md
+++ b/README.md
@@ -7,18 +7,15 @@ A library of readonly versions of Octokit types and their corresponding validato
 1. Copy `.env.example` to `.env` and set Personal Access Token with `repo` access.
 2. Run `npm run gh:apply-all` to update GitHub Repository Settings.
 3. Set Actions secrets on the GUI settings page (<https://github.com/{owner}/{repo}/settings/secrets/actions>).
-    - `NPM_TOKEN`
-        - Open <https://www.npmjs.com/settings/{your-user-id}/tokens> -> Generate New Token -> Classic Token -> Select `Automation` and generate.
-        - Required for semantic-release to run npm publish
-    - `SEMANTIC_RELEASE_GIT_PERMISSION_BOT_PRIVATE_KEY`
-        - <https://github.com/apps/semantic-release-git-permission> -> App settings -> Generate a private key
+    - `SEMANTIC_RELEASE_BOT_PRIVATE_KEY`
+        - <https://github.com/apps/noshiro-semantic-release-bot> -> App settings -> Generate a private key
         - Required for `@semantic-release/git` to perform a git commit to the main branch
     - `PERSONAL_ACCESS_TOKEN`
         - The same value as `1.`
         - Required for `.github/workflows/backup-repository-settings.yml` to run
 4. Set Dependabot secrets on the GUI settings page (<https://github.com/{owner}/{repo}/settings/secrets/dependabot>).
     - `DEPENDABOT_AUTO_MERGE_BOT_PRIVATE_KEY`
-        - <https://github.com/apps/dependabot-auto-merge-permissions> -> App settings -> Generate a private key
+        - <https://github.com/apps/noshiro-dependabot-auto-merge-bot> -> App settings -> Generate a private key
     - `PERSONAL_ACCESS_TOKEN`
         - The same value as `1.`
         - Required for `.github/workflows/backup-repository-settings.yml` to run


### PR DESCRIPTION
- actions/create-github-app-token の `app-id` 入力は deprecated
  （ action.yml に "Use 'client-id' instead." ）なので `client-id` に統一し、
  変数も *_CLIENT_ID に改名した。
- GitHub App のリネームに合わせて secret / variable 名を揃えた。
    SEMANTIC_RELEASE_GIT_PERMISSION_BOT_* -> SEMANTIC_RELEASE_BOT_*
    CHANGESETS_BOT_*                      -> CHANGESETS_RELEASE_BOT_*
  README / docs の App 名（ github.com/apps/... ）も新しい slug に更新した。
- release workflow から NPM_TOKEN を削除した。npm trusted publishing (OIDC)
  で認証しており、トークンは使われていない。
- 設定バックアップのトリガを main への push に限定した。branches-ignore だけ
  だったため Dependabot がブランチを push するたびに走っていた。

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)