### PR TITLE
fix: sync actions settings with the applied state

### DIFF
--- a/github/actions-settings/bk/settings.json
+++ b/github/actions-settings/bk/settings.json
@@ -2,5 +2,5 @@
   "enabled": true,
   "allowed_actions": "all",
   "sha_pinning_required": true,
-  "fork_pr_contributor_approval_policy": "first_time_contributors"
+  "fork_pr_contributor_approval_policy": "all_external_contributors"
 }

--- a/github/actions-settings/settings.json
+++ b/github/actions-settings/settings.json
@@ -2,5 +2,5 @@
   "enabled": true,
   "allowed_actions": "all",
   "sha_pinning_required": true,
-  "fork_pr_contributor_approval_policy": "first_time_contributors"
+  "fork_pr_contributor_approval_policy": "all_external_contributors"
 }


### PR DESCRIPTION
github/actions-settings/settings.json が fork_pr_contributor_approval_policy を
first_time_contributors のまま持っており、実際の設定（ all_external_contributors ）
と食い違っていた。このため main の backup-repository-settings が
assert-repo-is-clean で失敗していた。

他の 13 リポジトリと同じ基準値に揃える。実設定は既に基準どおりのため、
GitHub 側の変更は発生しない。

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)