### PR TITLE
chore(ci): let REPO_AUTOMATION_BOT bypass the main ruleset for releases

### DIFF
--- a/github/rulesets/main.json
+++ b/github/rulesets/main.json
@@ -10,7 +10,7 @@
       "bypass_mode": "always"
     },
     {
-      "actor_id": 1442563,
+      "actor_id": 4478721,
       "actor_type": "Integration",
       "bypass_mode": "always"
     }


### PR DESCRIPTION
`@semantic-release/git` はリリースコミットを `refs/heads/main` へ直接 push しますが、これは main ruleset の bypass actor にしか許されていません。bypass actor には廃止予定の `noshiro-semantic-release-bot`（ App 1442563 ）が残ったままだったため、release.yml を `REPO_AUTOMATION_BOT` に切り替えた時点で push が `GH013: Repository rule violations found for refs/heads/main` で失敗するようになりました。

Integration bypass actor を `noshiro-repo-automation-bot`（ App 4478721 ）に付け替え、release.yml と揃えます。

**merge しただけでは反映されません** — `repo-settings apply rulesets` の実行が必要です。